### PR TITLE
Update xmake.lua in assigment 8

### DIFF
--- a/src/Assignment8/xmake.lua
+++ b/src/Assignment8/xmake.lua
@@ -18,6 +18,7 @@ target("CGL")
     set_kind("static")
     add_packages("glew", "glfw", "freetype")
     add_files("CGL/src/*.cpp")
+    add_links("opengl32")
 
 target("main")
     set_kind("binary")


### PR DESCRIPTION
在使用mingw平台构建时，如果显示地添加opengl的链接，则会出现undefined reference的问题